### PR TITLE
Hack on heredoc rendering

### DIFF
--- a/terrafomo/src/Terrafomo/HCL.hs
+++ b/terrafomo/src/Terrafomo/HCL.hs
@@ -173,7 +173,7 @@ instance Pretty Value where
     pretty     = \case
         Null                    -> "null"
         String  x               -> PP.dquotes (pretty x)
-        HereDoc (pretty -> k) x -> "<<-" <> PP.vsep [k, pretty x, k]
+        HereDoc (pretty -> k) x -> "<<-" <> k <> PP.vsep [PP.nest (-9999) (PP.hardline <> pretty x), k]
         Number  x               -> pretty x
         Float   x               -> pretty x
         Bool    True            -> "true"


### PR DESCRIPTION
I couldn't quite find a way to inject an unsafe string, which is how I'd usually achieve something like this, but negative nesting seems to work (and is advertised in the documentation as a valid thing to do).